### PR TITLE
RDF Schema and JSONLD context generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-ipynb_checkpoints/
+.ipynb_checkpoints/

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+ipynb_checkpoints/

--- a/CordraToContext.py
+++ b/CordraToContext.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+import os
+import json
+import requests
+import numpy as np
+import copy
+
+# Collect all schemas
+
+def readJSON(fp):
+    with open(fp, 'r') as f:
+        return json.load(f)
+
+jsonSchemas = {j['title']: j for j in [readJSON(fp) for fp in os.listdir('.') if fp[-5:]=='.json']}
+
+allRefs = set()
+
+for name, schema in jsonSchemas.items():
+    currRefs = [ref for ref in schema['allOf'] if '$ref' in ref.keys()]
+    
+    for ref in currRefs:
+        allRefs.add(ref['$ref'].split('/')[-1])
+        
+
+def updateLists(v1, v2):
+    if not isinstance(v1, list):
+        return v2
+    if not isinstance(v2, list):
+        return v2
+    
+    for v2i in v2:
+        v1.append(v2i)
+    
+    return list(np.unique(v1))
+
+
+def updateDicts(d1, d2):
+    for k, v in d2.items():
+        d1[k] = updateLists(d1.get(k), v)
+        
+        
+def collapseListOfDicts(v):
+    w = dict()
+    
+    for vi in v:
+        k = vi["@id"]
+        if k in w:
+            updateDicts(w[k], vi)
+        else:
+            w[k] = vi
+            
+    return list(w.values())
+
+
+inSchemaOrg = lambda name: requests.get(f'https://schema.org/{name}').status_code == 200
+
+loc_main = "{0}.json".format
+loc_def = "definition-schemas/{0}.json".format
+
+# Context Template
+# [
+#   {
+#     "url": {
+#       "@id": "schema:url",
+#       "@type": "xsd:string"
+#     }
+#   }
+# ]
+
+def dPath(d, path):
+    for k in path.strip("/").split("/"):
+        if d:
+            d = d.get(k)
+        
+    return d
+
+G_classes = dict()
+G_properties = dict()
+
+for c in sorted(list(allRefs)):
+    print(c)
+    
+    classNode = {
+        "@id": f"schema:{c}"
+    }
+    
+    if not inSchemaOrg(c):
+        classNode = {
+            "@id": f"mat:{c}"
+        }
+        
+    G_classes[c] = classNode
+
+    try:
+        refs = [r for r in jsonSchemas[c]["allOf"] if "$ref" in r]
+        refs = [r for r in refs if r["$ref"].split("/")[-1] not in ("CordraObjectID", c)]
+        print(json.dumps(refs, indent=2))
+
+    except:
+        continue
+
+    for ref in refs:
+        
+        with open(ref['$ref'].split("#")[0], "r") as f:
+            data = json.load(f)
+            data = dPath(data, ref["$ref"].split("#")[1])
+
+        for pk, pv in data['properties'].items():
+            
+            propertyNode = {
+                "@id": f"schema:{pk}"
+            }
+
+            if not inSchemaOrg(pk):
+                propertyNode = {
+                    "@id": f"mat:{pk}"
+                }
+                
+            if 'items' in pv:
+                pv = pv.get('items')
+            
+            # Check if reference
+            r = dPath(pv, 'cordra/type/handleReference/types')
+            
+            if r:
+                propertyNode['@type'] = "@id"
+            elif ("url" in pk.lower()):
+                propertyNode['@type'] = "schema:URL"
+            elif ("date" in pk.lower()):
+                propertyNode['@type'] = "xsd:date"
+            elif (pv['type'] == 'string'):
+                propertyNode['@type'] = "xsd:string"
+            elif (pv['type'] == 'number'):
+                propertyNode['@type'] = "xsd:decimal" 
+            
+            G_properties[pk] = propertyNode
+
+    break
+
+
+G = copy.deepcopy(G_classes) 
+G.update(G_properties)
+
+
+matContext = {
+    "@context": {
+        "mat": "https://pages.nist.gov/material-schema/",
+        "mathub": "https://api.materialhub.org/objects/", 
+        "schema": "http://schema.org/",
+        "xsd": "https://www.w3.org/2001/XMLSchema#",
+        "skos": "http://www.w3.org/2004/02/skos/core#",
+        "broader": "skos:broader",
+        "narrower": "skos:narrower",
+        "related": "skos:related",
+        "exactMatch": "skos:exactMatch",
+        "closeMatch": "skos:closeMatch",
+    }
+}
+
+matContext["@context"].update(G)
+
+with open("context/matContext_auto.jsonld", "w+") as f:
+    f.write(json.dumps(matContext, indent=2))
+
+
+
+

--- a/CordraToRDFSchema.py
+++ b/CordraToRDFSchema.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+import os
+import json
+import requests
+import numpy as np
+import copy
+
+# Collect all schemas
+
+def readJSON(fp):
+    with open(fp, 'r') as f:
+        return json.load(f)
+
+jsonSchemas = {j['title']: j for j in [readJSON(fp) for fp in os.listdir('.') if fp[-5:]=='.json']}
+
+allRefs = set()
+
+for name, schema in jsonSchemas.items():
+    currRefs = [ref for ref in schema['allOf'] if '$ref' in ref.keys()]
+    
+    for ref in currRefs:
+        allRefs.add(ref['$ref'].split('/')[-1])
+        
+
+def updateLists(v1, v2):
+    if not isinstance(v1, list):
+        return v2
+    if not isinstance(v2, list):
+        return v2
+    
+    for v2i in v2:
+        v1.append(v2i)
+    
+    return list(np.unique(v1))
+
+
+def updateDicts(d1, d2):
+    for k, v in d2.items():
+        d1[k] = updateLists(d1.get(k), v)
+        
+        
+def collapseListOfDicts(v):
+    w = dict()
+    
+    for vi in v:
+        k = vi["@id"]
+        if k in w:
+            updateDicts(w[k], vi)
+        else:
+            w[k] = vi
+            
+    return list(w.values())
+
+
+inSchemaOrg = lambda name: requests.get(f'https://schema.org/{name}').status_code == 200
+
+loc_main = "{0}.json".format
+loc_def = "definition-schemas/{0}.json".format
+
+# RDF Schema Template
+# [
+#     {
+#         @id: mat:...,
+#         @type: rdfs:Class OR rdfs:Property,
+#         rdfs:label: ...,
+#         rdfs:subClassOf: ...,
+#         schema:domainIncludes: {
+#             @id: ...
+#         },
+#         schema:rangeIncludes: {
+#             @id: ...
+#         }
+#     }
+# ]
+
+def dPath(d, path):
+    for k in path.strip("/").split("/"):
+        if d:
+            d = d.get(k)
+        
+    return d
+
+G_classes = []
+G_properties = []
+
+for c in sorted(list(allRefs)):
+    print(c)
+    
+    classNode = {
+        "@id": f"schema:{c}",
+        "@type": "rdfs:Class",
+        "rdfs:label": c
+    }
+    
+    if not inSchemaOrg(c):
+        classNode = {
+            "@id": f"mat:{c}",
+            "@type": "rdfs:Class",
+            "rdfs:label": c
+        }
+        
+    try:
+        refs = [r for r in jsonSchemas[c]["allOf"] if "$ref" in r]
+        refs = [r for r in refs if r["$ref"].split("/")[-1] not in ("CordraObjectID", c)]
+        print(json.dumps(refs, indent=2))
+
+    except:
+        continue
+
+    superClasses = []
+
+    for r in refs:
+        name = r["$ref"].split("/")[-1]
+
+        if inSchemaOrg(name):
+            superClasses.append(f"schema:{name}")
+        else:
+            superClasses.append(f"mat:{name}")
+
+    classNode["rdfs:subClassOf"] = superClasses
+
+    propertyNodes = []
+
+    for ref in refs:
+        className = ref["$ref"].split("/")[-1]
+        
+        with open(ref['$ref'].split("#")[0], "r") as f:
+            data = json.load(f)
+            data = dPath(data, ref["$ref"].split("#")[1])
+
+        for pk, pv in data['properties'].items():
+            
+            propertyNode = {
+                "@id": f"schema:{pk}",
+                "@type": "rdfs:Property",
+                "rdfs:label": pk,
+                "schema:domainIncludes": [className]
+            }
+
+            if not inSchemaOrg(pk):
+                propertyNode = {
+                    "@id": f"mat:{pk}",
+                    "@type": "rdfs:Property",
+                    "rdfs:label": pk,
+                    "schema:domainIncludes": [className]
+                }
+                
+            if 'items' in pv:
+                pv = pv.get('items')
+            
+            r = dPath(pv, 'cordra/type/handleReference/types')
+            
+            if r:
+                propertyNode['schema:rangeIncludes'] = r
+                
+                
+            
+            propertyNodes.append(propertyNode)
+
+    G_classes.append(classNode)
+
+    for propertyNode in propertyNodes:
+        G_properties.append(propertyNode)
+
+
+G = copy.deepcopy(G_classes) + collapseListOfDicts(G_properties)
+
+
+
+G_mat = [g for g in G if "mat:" in g["@id"]]
+
+
+# Thing, CreativeWork rule
+## If Thing and Creativework in a subclass of property, replace with CreativeWork
+def removeThing(v):
+    return list(filter(lambda vi: vi!="schema:Thing", v))
+
+for d in G_mat:
+    v = d.get("rdfs:subClassOf", [])
+    if "schema:Thing" in v and "schema:CreativeWork" in v:
+        d["rdfs:subClassOf"] = removeThing(v)
+            
+            
+print(json.dumps(G_mat, indent=2))
+
+
+matSchemas = {
+    "@context": {
+        "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+        "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+        "schema": "https://schema.org/",
+        "xsd": "http://www.w3.org/2001/XMLSchema#",
+        "mat": "https://pages.nist.gov/material-schema/"
+    },
+    "@graph": G
+}
+
+with open("RDF/material-schema_auto.jsonld", "w+") as f:
+    f.write(json.dumps(matSchemas, indent=2))
+
+
+
+

--- a/RDF/material-schema_auto.jsonld
+++ b/RDF/material-schema_auto.jsonld
@@ -98,8 +98,7 @@
       "rdfs:label": "Instrument",
       "rdfs:subClassOf": [
         "schema:CreativeWork",
-        "schema:Product",
-        "schema:Action"
+        "schema:Product"
       ]
     },
     {
@@ -166,8 +165,7 @@
       "rdfs:label": "SoftwareApplication",
       "rdfs:subClassOf": [
         "schema:Thing",
-        "schema:CreativeWork",
-        "schema:Action"
+        "schema:CreativeWork"
       ]
     },
     {
@@ -215,7 +213,7 @@
     },
     {
       "@id": "schema:identifier",
-      "@type": "rdfs:Class",
+      "@type": "rdfs:Property",
       "rdfs:label": "identifier",
       "schema:domainIncludes": [
         "Thing"
@@ -223,7 +221,7 @@
     },
     {
       "@id": "schema:name",
-      "@type": "rdfs:Class",
+      "@type": "rdfs:Property",
       "rdfs:label": "name",
       "schema:domainIncludes": [
         "Thing"
@@ -231,7 +229,7 @@
     },
     {
       "@id": "schema:alternateName",
-      "@type": "rdfs:Class",
+      "@type": "rdfs:Property",
       "rdfs:label": "alternateName",
       "schema:domainIncludes": [
         "Thing"
@@ -239,7 +237,7 @@
     },
     {
       "@id": "schema:description",
-      "@type": "rdfs:Class",
+      "@type": "rdfs:Property",
       "rdfs:label": "description",
       "schema:domainIncludes": [
         "Thing"
@@ -247,7 +245,7 @@
     },
     {
       "@id": "schema:url",
-      "@type": "rdfs:Class",
+      "@type": "rdfs:Property",
       "rdfs:label": "url",
       "schema:domainIncludes": [
         "Thing"
@@ -255,7 +253,7 @@
     },
     {
       "@id": "schema:image",
-      "@type": "rdfs:Class",
+      "@type": "rdfs:Property",
       "rdfs:label": "image",
       "schema:domainIncludes": [
         "Thing"
@@ -263,7 +261,7 @@
     },
     {
       "@id": "schema:subjectOf",
-      "@type": "rdfs:Class",
+      "@type": "rdfs:Property",
       "rdfs:label": "subjectOf",
       "schema:domainIncludes": [
         "Thing"
@@ -271,7 +269,7 @@
     },
     {
       "@id": "schema:about",
-      "@type": "rdfs:Class",
+      "@type": "rdfs:Property",
       "rdfs:label": "about",
       "schema:domainIncludes": [
         "CreativeWork"
@@ -279,7 +277,7 @@
     },
     {
       "@id": "schema:keywords",
-      "@type": "rdfs:Class",
+      "@type": "rdfs:Property",
       "rdfs:label": "keywords",
       "schema:domainIncludes": [
         "CreativeWork"
@@ -287,7 +285,7 @@
     },
     {
       "@id": "schema:citation",
-      "@type": "rdfs:Class",
+      "@type": "rdfs:Property",
       "rdfs:label": "citation",
       "schema:domainIncludes": [
         "CreativeWork"
@@ -295,7 +293,7 @@
     },
     {
       "@id": "schema:funder",
-      "@type": "rdfs:Class",
+      "@type": "rdfs:Property",
       "rdfs:label": "funder",
       "schema:domainIncludes": [
         "CreativeWork"
@@ -308,7 +306,7 @@
     },
     {
       "@id": "schema:accountablePerson",
-      "@type": "rdfs:Class",
+      "@type": "rdfs:Property",
       "rdfs:label": "accountablePerson",
       "schema:domainIncludes": [
         "CreativeWork"
@@ -320,7 +318,7 @@
     },
     {
       "@id": "schema:author",
-      "@type": "rdfs:Class",
+      "@type": "rdfs:Property",
       "rdfs:label": "author",
       "schema:domainIncludes": [
         "CreativeWork"
@@ -333,7 +331,7 @@
     },
     {
       "@id": "schema:editor",
-      "@type": "rdfs:Class",
+      "@type": "rdfs:Property",
       "rdfs:label": "editor",
       "schema:domainIncludes": [
         "CreativeWork"
@@ -345,7 +343,7 @@
     },
     {
       "@id": "schema:creator",
-      "@type": "rdfs:Class",
+      "@type": "rdfs:Property",
       "rdfs:label": "creator",
       "schema:domainIncludes": [
         "CreativeWork"
@@ -358,7 +356,7 @@
     },
     {
       "@id": "schema:contributor",
-      "@type": "rdfs:Class",
+      "@type": "rdfs:Property",
       "rdfs:label": "contributor",
       "schema:domainIncludes": [
         "CreativeWork"
@@ -371,7 +369,7 @@
     },
     {
       "@id": "schema:provider",
-      "@type": "rdfs:Class",
+      "@type": "rdfs:Property",
       "rdfs:label": "provider",
       "schema:domainIncludes": [
         "CreativeWork"
@@ -384,7 +382,7 @@
     },
     {
       "@id": "schema:publisher",
-      "@type": "rdfs:Class",
+      "@type": "rdfs:Property",
       "rdfs:label": "publisher",
       "schema:domainIncludes": [
         "CreativeWork"
@@ -397,7 +395,7 @@
     },
     {
       "@id": "schema:copyrightHolder",
-      "@type": "rdfs:Class",
+      "@type": "rdfs:Property",
       "rdfs:label": "copyrightHolder",
       "schema:domainIncludes": [
         "CreativeWork"
@@ -410,7 +408,7 @@
     },
     {
       "@id": "schema:license",
-      "@type": "rdfs:Class",
+      "@type": "rdfs:Property",
       "rdfs:label": "license",
       "schema:domainIncludes": [
         "CreativeWork"
@@ -418,7 +416,7 @@
     },
     {
       "@id": "schema:thumbnailUrl",
-      "@type": "rdfs:Class",
+      "@type": "rdfs:Property",
       "rdfs:label": "thumbnailUrl",
       "schema:domainIncludes": [
         "CreativeWork"
@@ -426,7 +424,7 @@
     },
     {
       "@id": "schema:dateCreated",
-      "@type": "rdfs:Class",
+      "@type": "rdfs:Property",
       "rdfs:label": "dateCreated",
       "schema:domainIncludes": [
         "CreativeWork"
@@ -434,7 +432,7 @@
     },
     {
       "@id": "schema:dateModified",
-      "@type": "rdfs:Class",
+      "@type": "rdfs:Property",
       "rdfs:label": "dateModified",
       "schema:domainIncludes": [
         "CreativeWork"
@@ -442,7 +440,7 @@
     },
     {
       "@id": "schema:datePublished",
-      "@type": "rdfs:Class",
+      "@type": "rdfs:Property",
       "rdfs:label": "datePublished",
       "schema:domainIncludes": [
         "CreativeWork"
@@ -450,7 +448,7 @@
     },
     {
       "@id": "schema:comment",
-      "@type": "rdfs:Class",
+      "@type": "rdfs:Property",
       "rdfs:label": "comment",
       "schema:domainIncludes": [
         "CreativeWork"
@@ -461,7 +459,7 @@
     },
     {
       "@id": "schema:spatial",
-      "@type": "rdfs:Class",
+      "@type": "rdfs:Property",
       "rdfs:label": "spatial",
       "schema:domainIncludes": [
         "CreativeWork"
@@ -472,7 +470,7 @@
     },
     {
       "@id": "schema:manufacturer",
-      "@type": "rdfs:Class",
+      "@type": "rdfs:Property",
       "rdfs:label": "manufacturer",
       "schema:domainIncludes": [
         "Product"
@@ -485,7 +483,7 @@
     },
     {
       "@id": "schema:brand",
-      "@type": "rdfs:Class",
+      "@type": "rdfs:Property",
       "rdfs:label": "brand",
       "schema:domainIncludes": [
         "Product"
@@ -493,7 +491,7 @@
     },
     {
       "@id": "schema:model",
-      "@type": "rdfs:Class",
+      "@type": "rdfs:Property",
       "rdfs:label": "model",
       "schema:domainIncludes": [
         "Product"
@@ -501,7 +499,7 @@
     },
     {
       "@id": "schema:productID",
-      "@type": "rdfs:Class",
+      "@type": "rdfs:Property",
       "rdfs:label": "productID",
       "schema:domainIncludes": [
         "Product"
@@ -509,7 +507,7 @@
     },
     {
       "@id": "schema:productionDate",
-      "@type": "rdfs:Class",
+      "@type": "rdfs:Property",
       "rdfs:label": "productionDate",
       "schema:domainIncludes": [
         "Product"
@@ -517,7 +515,7 @@
     },
     {
       "@id": "schema:purchaseDate",
-      "@type": "rdfs:Class",
+      "@type": "rdfs:Property",
       "rdfs:label": "purchaseDate",
       "schema:domainIncludes": [
         "Product"
@@ -525,55 +523,10 @@
     },
     {
       "@id": "schema:serialNumber",
-      "@type": "rdfs:Class",
+      "@type": "rdfs:Property",
       "rdfs:label": "serialNumber",
       "schema:domainIncludes": [
         "Product"
-      ]
-    },
-    {
-      "@id": "schema:object",
-      "@type": "rdfs:Class",
-      "rdfs:label": "object",
-      "schema:domainIncludes": [
-        "Action"
-      ],
-      "schema:rangeIncludes": [
-        "Material",
-        "MaterialProperty",
-        "MaterialStructure",
-        "ProcessHistory",
-        "ProcessProtocol"
-      ]
-    },
-    {
-      "@id": "schema:result",
-      "@type": "rdfs:Class",
-      "rdfs:label": "result",
-      "schema:domainIncludes": [
-        "Action"
-      ],
-      "schema:rangeIncludes": [
-        "Material",
-        "MaterialProperty",
-        "MaterialStructure",
-        "ProcessHistory",
-        "ProcessProtocol"
-      ]
-    },
-    {
-      "@id": "schema:target",
-      "@type": "rdfs:Class",
-      "rdfs:label": "target",
-      "schema:domainIncludes": [
-        "Action"
-      ],
-      "schema:rangeIncludes": [
-        "Material",
-        "MaterialProperty",
-        "MaterialStructure",
-        "ProcessHistory",
-        "ProcessProtocol"
       ]
     },
     {
@@ -610,7 +563,7 @@
     },
     {
       "@id": "schema:measurementTechnique",
-      "@type": "rdfs:Class",
+      "@type": "rdfs:Property",
       "rdfs:label": "measurementTechnique",
       "schema:domainIncludes": [
         "File"
@@ -618,7 +571,7 @@
     },
     {
       "@id": "schema:variableMeasured",
-      "@type": "rdfs:Class",
+      "@type": "rdfs:Property",
       "rdfs:label": "variableMeasured",
       "schema:domainIncludes": [
         "File"
@@ -642,7 +595,7 @@
     },
     {
       "@id": "schema:material",
-      "@type": "rdfs:Class",
+      "@type": "rdfs:Property",
       "rdfs:label": "material",
       "schema:domainIncludes": [
         "File"
@@ -650,7 +603,7 @@
     },
     {
       "@id": "schema:materialExtent",
-      "@type": "rdfs:Class",
+      "@type": "rdfs:Property",
       "rdfs:label": "materialExtent",
       "schema:domainIncludes": [
         "File"
@@ -674,7 +627,7 @@
     },
     {
       "@id": "schema:includedInDataCatalog",
-      "@type": "rdfs:Class",
+      "@type": "rdfs:Property",
       "rdfs:label": "includedInDataCatalog",
       "schema:domainIncludes": [
         "File"
@@ -682,7 +635,7 @@
     },
     {
       "@id": "schema:uploadDate",
-      "@type": "rdfs:Class",
+      "@type": "rdfs:Property",
       "rdfs:label": "uploadDate",
       "schema:domainIncludes": [
         "File"
@@ -690,7 +643,7 @@
     },
     {
       "@id": "schema:distribution",
-      "@type": "rdfs:Class",
+      "@type": "rdfs:Property",
       "rdfs:label": "distribution",
       "schema:domainIncludes": [
         "File"
@@ -698,7 +651,7 @@
     },
     {
       "@id": "schema:hasPart",
-      "@type": "rdfs:Class",
+      "@type": "rdfs:Property",
       "rdfs:label": "hasPart",
       "schema:domainIncludes": [
         "File"
@@ -706,7 +659,7 @@
     },
     {
       "@id": "schema:isPartOf",
-      "@type": "rdfs:Class",
+      "@type": "rdfs:Property",
       "rdfs:label": "isPartOf",
       "schema:domainIncludes": [
         "File"
@@ -714,7 +667,7 @@
     },
     {
       "@id": "schema:isBasedOn",
-      "@type": "rdfs:Class",
+      "@type": "rdfs:Property",
       "rdfs:label": "isBasedOn",
       "schema:domainIncludes": [
         "File"
@@ -722,7 +675,7 @@
     },
     {
       "@id": "schema:exampleOfWork",
-      "@type": "rdfs:Class",
+      "@type": "rdfs:Property",
       "rdfs:label": "exampleOfWork",
       "schema:domainIncludes": [
         "File"

--- a/RDF/material-schema_auto.jsonld
+++ b/RDF/material-schema_auto.jsonld
@@ -1,0 +1,732 @@
+{
+  "@context": {
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "schema": "https://schema.org/",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "mat": "https://pages.nist.gov/material-schema/"
+  },
+  "@graph": [
+    {
+      "@id": "schema:Collection",
+      "@type": "rdfs:Class",
+      "rdfs:label": "Collection",
+      "rdfs:subClassOf": [
+        "schema:Thing",
+        "schema:CreativeWork"
+      ]
+    },
+    {
+      "@id": "schema:Comment",
+      "@type": "rdfs:Class",
+      "rdfs:label": "Comment",
+      "rdfs:subClassOf": [
+        "schema:Thing",
+        "schema:CreativeWork"
+      ]
+    },
+    {
+      "@id": "schema:DataCatalog",
+      "@type": "rdfs:Class",
+      "rdfs:label": "DataCatalog",
+      "rdfs:subClassOf": [
+        "schema:Thing",
+        "schema:CreativeWork"
+      ]
+    },
+    {
+      "@id": "mat:DataFormat",
+      "@type": "rdfs:Class",
+      "rdfs:label": "DataFormat",
+      "rdfs:subClassOf": [
+        "schema:CreativeWork"
+      ]
+    },
+    {
+      "@id": "schema:Dataset",
+      "@type": "rdfs:Class",
+      "rdfs:label": "Dataset",
+      "rdfs:subClassOf": [
+        "schema:Thing",
+        "schema:CreativeWork"
+      ]
+    },
+    {
+      "@id": "schema:DefinedTerm",
+      "@type": "rdfs:Class",
+      "rdfs:label": "DefinedTerm",
+      "rdfs:subClassOf": [
+        "schema:Thing"
+      ]
+    },
+    {
+      "@id": "schema:DefinedTermSet",
+      "@type": "rdfs:Class",
+      "rdfs:label": "DefinedTermSet",
+      "rdfs:subClassOf": [
+        "schema:Thing",
+        "schema:CreativeWork"
+      ]
+    },
+    {
+      "@id": "mat:DutyAction",
+      "@type": "rdfs:Class",
+      "rdfs:label": "DutyAction",
+      "rdfs:subClassOf": [
+        "schema:Thing"
+      ]
+    },
+    {
+      "@id": "mat:Experiment",
+      "@type": "rdfs:Class",
+      "rdfs:label": "Experiment",
+      "rdfs:subClassOf": [
+        "schema:CreativeWork"
+      ]
+    },
+    {
+      "@id": "mat:File",
+      "@type": "rdfs:Class",
+      "rdfs:label": "File",
+      "rdfs:subClassOf": [
+        "schema:CreativeWork"
+      ]
+    },
+    {
+      "@id": "mat:Instrument",
+      "@type": "rdfs:Class",
+      "rdfs:label": "Instrument",
+      "rdfs:subClassOf": [
+        "schema:CreativeWork",
+        "schema:Product",
+        "schema:Action"
+      ]
+    },
+    {
+      "@id": "mat:InstrumentAction",
+      "@type": "rdfs:Class",
+      "rdfs:label": "InstrumentAction",
+      "rdfs:subClassOf": [
+        "schema:Thing"
+      ]
+    },
+    {
+      "@id": "mat:Material",
+      "@type": "rdfs:Class",
+      "rdfs:label": "Material",
+      "rdfs:subClassOf": [
+        "schema:CreativeWork",
+        "schema:Product"
+      ]
+    },
+    {
+      "@id": "mat:MaterialProperty",
+      "@type": "rdfs:Class",
+      "rdfs:label": "MaterialProperty",
+      "rdfs:subClassOf": [
+        "schema:CreativeWork"
+      ]
+    },
+    {
+      "@id": "schema:Organization",
+      "@type": "rdfs:Class",
+      "rdfs:label": "Organization",
+      "rdfs:subClassOf": [
+        "schema:Thing"
+      ]
+    },
+    {
+      "@id": "schema:Person",
+      "@type": "rdfs:Class",
+      "rdfs:label": "Person",
+      "rdfs:subClassOf": [
+        "mat:CordraUser",
+        "schema:Thing"
+      ]
+    },
+    {
+      "@id": "schema:Place",
+      "@type": "rdfs:Class",
+      "rdfs:label": "Place",
+      "rdfs:subClassOf": [
+        "schema:Thing"
+      ]
+    },
+    {
+      "@id": "schema:Project",
+      "@type": "rdfs:Class",
+      "rdfs:label": "Project",
+      "rdfs:subClassOf": [
+        "schema:Thing"
+      ]
+    },
+    {
+      "@id": "schema:SoftwareApplication",
+      "@type": "rdfs:Class",
+      "rdfs:label": "SoftwareApplication",
+      "rdfs:subClassOf": [
+        "schema:Thing",
+        "schema:CreativeWork",
+        "schema:Action"
+      ]
+    },
+    {
+      "@id": "schema:SoftwareSourceCode",
+      "@type": "rdfs:Class",
+      "rdfs:label": "SoftwareSourceCode",
+      "rdfs:subClassOf": [
+        "schema:Thing",
+        "schema:CreativeWork"
+      ]
+    },
+    {
+      "@id": "mat:Study",
+      "@type": "rdfs:Class",
+      "rdfs:label": "Study",
+      "rdfs:subClassOf": [
+        "schema:CreativeWork"
+      ]
+    },
+    {
+      "@id": "mat:TabularData",
+      "@type": "rdfs:Class",
+      "rdfs:label": "TabularData",
+      "rdfs:subClassOf": [
+        "schema:CreativeWork",
+        "mat:File"
+      ]
+    },
+    {
+      "@id": "mat:TabularDataPackage",
+      "@type": "rdfs:Class",
+      "rdfs:label": "TabularDataPackage",
+      "rdfs:subClassOf": [
+        "schema:CreativeWork",
+        "mat:File"
+      ]
+    },
+    {
+      "@id": "mat:UnitOfMeasurement",
+      "@type": "rdfs:Class",
+      "rdfs:label": "UnitOfMeasurement",
+      "rdfs:subClassOf": [
+        "schema:Thing"
+      ]
+    },
+    {
+      "@id": "schema:identifier",
+      "@type": "rdfs:Class",
+      "rdfs:label": "identifier",
+      "schema:domainIncludes": [
+        "Thing"
+      ]
+    },
+    {
+      "@id": "schema:name",
+      "@type": "rdfs:Class",
+      "rdfs:label": "name",
+      "schema:domainIncludes": [
+        "Thing"
+      ]
+    },
+    {
+      "@id": "schema:alternateName",
+      "@type": "rdfs:Class",
+      "rdfs:label": "alternateName",
+      "schema:domainIncludes": [
+        "Thing"
+      ]
+    },
+    {
+      "@id": "schema:description",
+      "@type": "rdfs:Class",
+      "rdfs:label": "description",
+      "schema:domainIncludes": [
+        "Thing"
+      ]
+    },
+    {
+      "@id": "schema:url",
+      "@type": "rdfs:Class",
+      "rdfs:label": "url",
+      "schema:domainIncludes": [
+        "Thing"
+      ]
+    },
+    {
+      "@id": "schema:image",
+      "@type": "rdfs:Class",
+      "rdfs:label": "image",
+      "schema:domainIncludes": [
+        "Thing"
+      ]
+    },
+    {
+      "@id": "schema:subjectOf",
+      "@type": "rdfs:Class",
+      "rdfs:label": "subjectOf",
+      "schema:domainIncludes": [
+        "Thing"
+      ]
+    },
+    {
+      "@id": "schema:about",
+      "@type": "rdfs:Class",
+      "rdfs:label": "about",
+      "schema:domainIncludes": [
+        "CreativeWork"
+      ]
+    },
+    {
+      "@id": "schema:keywords",
+      "@type": "rdfs:Class",
+      "rdfs:label": "keywords",
+      "schema:domainIncludes": [
+        "CreativeWork"
+      ]
+    },
+    {
+      "@id": "schema:citation",
+      "@type": "rdfs:Class",
+      "rdfs:label": "citation",
+      "schema:domainIncludes": [
+        "CreativeWork"
+      ]
+    },
+    {
+      "@id": "schema:funder",
+      "@type": "rdfs:Class",
+      "rdfs:label": "funder",
+      "schema:domainIncludes": [
+        "CreativeWork"
+      ],
+      "schema:rangeIncludes": [
+        "Organization",
+        "Person",
+        "User"
+      ]
+    },
+    {
+      "@id": "schema:accountablePerson",
+      "@type": "rdfs:Class",
+      "rdfs:label": "accountablePerson",
+      "schema:domainIncludes": [
+        "CreativeWork"
+      ],
+      "schema:rangeIncludes": [
+        "Person",
+        "User"
+      ]
+    },
+    {
+      "@id": "schema:author",
+      "@type": "rdfs:Class",
+      "rdfs:label": "author",
+      "schema:domainIncludes": [
+        "CreativeWork"
+      ],
+      "schema:rangeIncludes": [
+        "Organization",
+        "Person",
+        "User"
+      ]
+    },
+    {
+      "@id": "schema:editor",
+      "@type": "rdfs:Class",
+      "rdfs:label": "editor",
+      "schema:domainIncludes": [
+        "CreativeWork"
+      ],
+      "schema:rangeIncludes": [
+        "Person",
+        "User"
+      ]
+    },
+    {
+      "@id": "schema:creator",
+      "@type": "rdfs:Class",
+      "rdfs:label": "creator",
+      "schema:domainIncludes": [
+        "CreativeWork"
+      ],
+      "schema:rangeIncludes": [
+        "Organization",
+        "Person",
+        "User"
+      ]
+    },
+    {
+      "@id": "schema:contributor",
+      "@type": "rdfs:Class",
+      "rdfs:label": "contributor",
+      "schema:domainIncludes": [
+        "CreativeWork"
+      ],
+      "schema:rangeIncludes": [
+        "Organization",
+        "Person",
+        "User"
+      ]
+    },
+    {
+      "@id": "schema:provider",
+      "@type": "rdfs:Class",
+      "rdfs:label": "provider",
+      "schema:domainIncludes": [
+        "CreativeWork"
+      ],
+      "schema:rangeIncludes": [
+        "Organization",
+        "Person",
+        "User"
+      ]
+    },
+    {
+      "@id": "schema:publisher",
+      "@type": "rdfs:Class",
+      "rdfs:label": "publisher",
+      "schema:domainIncludes": [
+        "CreativeWork"
+      ],
+      "schema:rangeIncludes": [
+        "Organization",
+        "Person",
+        "User"
+      ]
+    },
+    {
+      "@id": "schema:copyrightHolder",
+      "@type": "rdfs:Class",
+      "rdfs:label": "copyrightHolder",
+      "schema:domainIncludes": [
+        "CreativeWork"
+      ],
+      "schema:rangeIncludes": [
+        "Organization",
+        "Person",
+        "User"
+      ]
+    },
+    {
+      "@id": "schema:license",
+      "@type": "rdfs:Class",
+      "rdfs:label": "license",
+      "schema:domainIncludes": [
+        "CreativeWork"
+      ]
+    },
+    {
+      "@id": "schema:thumbnailUrl",
+      "@type": "rdfs:Class",
+      "rdfs:label": "thumbnailUrl",
+      "schema:domainIncludes": [
+        "CreativeWork"
+      ]
+    },
+    {
+      "@id": "schema:dateCreated",
+      "@type": "rdfs:Class",
+      "rdfs:label": "dateCreated",
+      "schema:domainIncludes": [
+        "CreativeWork"
+      ]
+    },
+    {
+      "@id": "schema:dateModified",
+      "@type": "rdfs:Class",
+      "rdfs:label": "dateModified",
+      "schema:domainIncludes": [
+        "CreativeWork"
+      ]
+    },
+    {
+      "@id": "schema:datePublished",
+      "@type": "rdfs:Class",
+      "rdfs:label": "datePublished",
+      "schema:domainIncludes": [
+        "CreativeWork"
+      ]
+    },
+    {
+      "@id": "schema:comment",
+      "@type": "rdfs:Class",
+      "rdfs:label": "comment",
+      "schema:domainIncludes": [
+        "CreativeWork"
+      ],
+      "schema:rangeIncludes": [
+        "Comment"
+      ]
+    },
+    {
+      "@id": "schema:spatial",
+      "@type": "rdfs:Class",
+      "rdfs:label": "spatial",
+      "schema:domainIncludes": [
+        "CreativeWork"
+      ],
+      "schema:rangeIncludes": [
+        "Place"
+      ]
+    },
+    {
+      "@id": "schema:manufacturer",
+      "@type": "rdfs:Class",
+      "rdfs:label": "manufacturer",
+      "schema:domainIncludes": [
+        "Product"
+      ],
+      "schema:rangeIncludes": [
+        "Organization",
+        "Person",
+        "User"
+      ]
+    },
+    {
+      "@id": "schema:brand",
+      "@type": "rdfs:Class",
+      "rdfs:label": "brand",
+      "schema:domainIncludes": [
+        "Product"
+      ]
+    },
+    {
+      "@id": "schema:model",
+      "@type": "rdfs:Class",
+      "rdfs:label": "model",
+      "schema:domainIncludes": [
+        "Product"
+      ]
+    },
+    {
+      "@id": "schema:productID",
+      "@type": "rdfs:Class",
+      "rdfs:label": "productID",
+      "schema:domainIncludes": [
+        "Product"
+      ]
+    },
+    {
+      "@id": "schema:productionDate",
+      "@type": "rdfs:Class",
+      "rdfs:label": "productionDate",
+      "schema:domainIncludes": [
+        "Product"
+      ]
+    },
+    {
+      "@id": "schema:purchaseDate",
+      "@type": "rdfs:Class",
+      "rdfs:label": "purchaseDate",
+      "schema:domainIncludes": [
+        "Product"
+      ]
+    },
+    {
+      "@id": "schema:serialNumber",
+      "@type": "rdfs:Class",
+      "rdfs:label": "serialNumber",
+      "schema:domainIncludes": [
+        "Product"
+      ]
+    },
+    {
+      "@id": "schema:object",
+      "@type": "rdfs:Class",
+      "rdfs:label": "object",
+      "schema:domainIncludes": [
+        "Action"
+      ],
+      "schema:rangeIncludes": [
+        "Material",
+        "MaterialProperty",
+        "MaterialStructure",
+        "ProcessHistory",
+        "ProcessProtocol"
+      ]
+    },
+    {
+      "@id": "schema:result",
+      "@type": "rdfs:Class",
+      "rdfs:label": "result",
+      "schema:domainIncludes": [
+        "Action"
+      ],
+      "schema:rangeIncludes": [
+        "Material",
+        "MaterialProperty",
+        "MaterialStructure",
+        "ProcessHistory",
+        "ProcessProtocol"
+      ]
+    },
+    {
+      "@id": "schema:target",
+      "@type": "rdfs:Class",
+      "rdfs:label": "target",
+      "schema:domainIncludes": [
+        "Action"
+      ],
+      "schema:rangeIncludes": [
+        "Material",
+        "MaterialProperty",
+        "MaterialStructure",
+        "ProcessHistory",
+        "ProcessProtocol"
+      ]
+    },
+    {
+      "@id": "mat:username",
+      "@type": "rdfs:Property",
+      "rdfs:label": "username",
+      "schema:domainIncludes": [
+        "CordraUser"
+      ]
+    },
+    {
+      "@id": "mat:password",
+      "@type": "rdfs:Property",
+      "rdfs:label": "password",
+      "schema:domainIncludes": [
+        "CordraUser"
+      ]
+    },
+    {
+      "@id": "mat:requirePasswordChange",
+      "@type": "rdfs:Property",
+      "rdfs:label": "requirePasswordChange",
+      "schema:domainIncludes": [
+        "CordraUser"
+      ]
+    },
+    {
+      "@id": "mat:publicKey",
+      "@type": "rdfs:Property",
+      "rdfs:label": "publicKey",
+      "schema:domainIncludes": [
+        "CordraUser"
+      ]
+    },
+    {
+      "@id": "schema:measurementTechnique",
+      "@type": "rdfs:Class",
+      "rdfs:label": "measurementTechnique",
+      "schema:domainIncludes": [
+        "File"
+      ]
+    },
+    {
+      "@id": "schema:variableMeasured",
+      "@type": "rdfs:Class",
+      "rdfs:label": "variableMeasured",
+      "schema:domainIncludes": [
+        "File"
+      ]
+    },
+    {
+      "@id": "mat:parameterControlled",
+      "@type": "rdfs:Property",
+      "rdfs:label": "parameterControlled",
+      "schema:domainIncludes": [
+        "File"
+      ]
+    },
+    {
+      "@id": "mat:conditionObserved",
+      "@type": "rdfs:Property",
+      "rdfs:label": "conditionObserved",
+      "schema:domainIncludes": [
+        "File"
+      ]
+    },
+    {
+      "@id": "schema:material",
+      "@type": "rdfs:Class",
+      "rdfs:label": "material",
+      "schema:domainIncludes": [
+        "File"
+      ]
+    },
+    {
+      "@id": "schema:materialExtent",
+      "@type": "rdfs:Class",
+      "rdfs:label": "materialExtent",
+      "schema:domainIncludes": [
+        "File"
+      ]
+    },
+    {
+      "@id": "mat:materialReference",
+      "@type": "rdfs:Property",
+      "rdfs:label": "materialReference",
+      "schema:domainIncludes": [
+        "File"
+      ]
+    },
+    {
+      "@id": "mat:materialReferenceExtent",
+      "@type": "rdfs:Property",
+      "rdfs:label": "materialReferenceExtent",
+      "schema:domainIncludes": [
+        "File"
+      ]
+    },
+    {
+      "@id": "schema:includedInDataCatalog",
+      "@type": "rdfs:Class",
+      "rdfs:label": "includedInDataCatalog",
+      "schema:domainIncludes": [
+        "File"
+      ]
+    },
+    {
+      "@id": "schema:uploadDate",
+      "@type": "rdfs:Class",
+      "rdfs:label": "uploadDate",
+      "schema:domainIncludes": [
+        "File"
+      ]
+    },
+    {
+      "@id": "schema:distribution",
+      "@type": "rdfs:Class",
+      "rdfs:label": "distribution",
+      "schema:domainIncludes": [
+        "File"
+      ]
+    },
+    {
+      "@id": "schema:hasPart",
+      "@type": "rdfs:Class",
+      "rdfs:label": "hasPart",
+      "schema:domainIncludes": [
+        "File"
+      ]
+    },
+    {
+      "@id": "schema:isPartOf",
+      "@type": "rdfs:Class",
+      "rdfs:label": "isPartOf",
+      "schema:domainIncludes": [
+        "File"
+      ]
+    },
+    {
+      "@id": "schema:isBasedOn",
+      "@type": "rdfs:Class",
+      "rdfs:label": "isBasedOn",
+      "schema:domainIncludes": [
+        "File"
+      ]
+    },
+    {
+      "@id": "schema:exampleOfWork",
+      "@type": "rdfs:Class",
+      "rdfs:label": "exampleOfWork",
+      "schema:domainIncludes": [
+        "File"
+      ]
+    }
+  ]
+}

--- a/context/matContext_auto.jsonld
+++ b/context/matContext_auto.jsonld
@@ -1,0 +1,123 @@
+{
+  "@context": {
+    "mat": "https://pages.nist.gov/material-schema/",
+    "mathub": "https://api.materialhub.org/objects/",
+    "schema": "http://schema.org/",
+    "xsd": "https://www.w3.org/2001/XMLSchema#",
+    "skos": "http://www.w3.org/2004/02/skos/core#",
+    "broader": "skos:broader",
+    "narrower": "skos:narrower",
+    "related": "skos:related",
+    "exactMatch": "skos:exactMatch",
+    "closeMatch": "skos:closeMatch",
+    "Action": {
+      "@id": "schema:Action"
+    },
+    "Collection": {
+      "@id": "schema:Collection"
+    },
+    "identifier": {
+      "@id": "schema:identifier"
+    },
+    "name": {
+      "@id": "schema:name",
+      "@type": "xsd:string"
+    },
+    "alternateName": {
+      "@id": "schema:alternateName",
+      "@type": "xsd:string"
+    },
+    "description": {
+      "@id": "schema:description",
+      "@type": "xsd:string"
+    },
+    "url": {
+      "@id": "schema:url",
+      "@type": "schema:URL"
+    },
+    "image": {
+      "@id": "schema:image",
+      "@type": "xsd:string"
+    },
+    "subjectOf": {
+      "@id": "schema:subjectOf",
+      "@type": "xsd:string"
+    },
+    "about": {
+      "@id": "schema:about",
+      "@type": "xsd:string"
+    },
+    "keywords": {
+      "@id": "schema:keywords",
+      "@type": "xsd:string"
+    },
+    "citation": {
+      "@id": "schema:citation",
+      "@type": "xsd:string"
+    },
+    "funder": {
+      "@id": "schema:funder",
+      "@type": "@id"
+    },
+    "accountablePerson": {
+      "@id": "schema:accountablePerson",
+      "@type": "@id"
+    },
+    "author": {
+      "@id": "schema:author",
+      "@type": "@id"
+    },
+    "editor": {
+      "@id": "schema:editor",
+      "@type": "@id"
+    },
+    "creator": {
+      "@id": "schema:creator",
+      "@type": "@id"
+    },
+    "contributor": {
+      "@id": "schema:contributor",
+      "@type": "@id"
+    },
+    "provider": {
+      "@id": "schema:provider",
+      "@type": "@id"
+    },
+    "publisher": {
+      "@id": "schema:publisher",
+      "@type": "@id"
+    },
+    "copyrightHolder": {
+      "@id": "schema:copyrightHolder",
+      "@type": "@id"
+    },
+    "license": {
+      "@id": "schema:license",
+      "@type": "xsd:string"
+    },
+    "thumbnailUrl": {
+      "@id": "schema:thumbnailUrl",
+      "@type": "schema:URL"
+    },
+    "dateCreated": {
+      "@id": "schema:dateCreated",
+      "@type": "xsd:date"
+    },
+    "dateModified": {
+      "@id": "schema:dateModified",
+      "@type": "xsd:date"
+    },
+    "datePublished": {
+      "@id": "schema:datePublished",
+      "@type": "xsd:date"
+    },
+    "comment": {
+      "@id": "schema:comment",
+      "@type": "@id"
+    },
+    "spatial": {
+      "@id": "schema:spatial",
+      "@type": "@id"
+    }
+  }
+}

--- a/context/matContext_auto.jsonld
+++ b/context/matContext_auto.jsonld
@@ -10,11 +10,98 @@
     "related": "skos:related",
     "exactMatch": "skos:exactMatch",
     "closeMatch": "skos:closeMatch",
-    "Action": {
-      "@id": "schema:Action"
-    },
     "Collection": {
       "@id": "schema:Collection"
+    },
+    "Comment": {
+      "@id": "schema:Comment"
+    },
+    "CordraGroup": {
+      "@id": "mat:CordraGroup"
+    },
+    "CordraObjectID": {
+      "@id": "mat:CordraObjectID"
+    },
+    "CordraUser": {
+      "@id": "mat:CordraUser"
+    },
+    "CreativeWork": {
+      "@id": "schema:CreativeWork"
+    },
+    "DataCatalog": {
+      "@id": "schema:DataCatalog"
+    },
+    "DataFormat": {
+      "@id": "mat:DataFormat"
+    },
+    "Dataset": {
+      "@id": "schema:Dataset"
+    },
+    "DefinedTerm": {
+      "@id": "schema:DefinedTerm"
+    },
+    "DefinedTermSet": {
+      "@id": "schema:DefinedTermSet"
+    },
+    "DutyAction": {
+      "@id": "mat:DutyAction"
+    },
+    "Experiment": {
+      "@id": "mat:Experiment"
+    },
+    "File": {
+      "@id": "mat:File"
+    },
+    "Instrument": {
+      "@id": "mat:Instrument"
+    },
+    "InstrumentAction": {
+      "@id": "mat:InstrumentAction"
+    },
+    "Material": {
+      "@id": "mat:Material"
+    },
+    "MaterialProperty": {
+      "@id": "mat:MaterialProperty"
+    },
+    "Organization": {
+      "@id": "schema:Organization"
+    },
+    "Person": {
+      "@id": "schema:Person"
+    },
+    "Place": {
+      "@id": "schema:Place"
+    },
+    "Process": {
+      "@id": "mat:Process"
+    },
+    "Product": {
+      "@id": "schema:Product"
+    },
+    "Project": {
+      "@id": "schema:Project"
+    },
+    "SoftwareApplication": {
+      "@id": "schema:SoftwareApplication"
+    },
+    "SoftwareSourceCode": {
+      "@id": "schema:SoftwareSourceCode"
+    },
+    "Study": {
+      "@id": "mat:Study"
+    },
+    "TabularData": {
+      "@id": "mat:TabularData"
+    },
+    "TabularDataPackage": {
+      "@id": "mat:TabularDataPackage"
+    },
+    "Thing": {
+      "@id": "schema:Thing"
+    },
+    "UnitOfMeasurement": {
+      "@id": "mat:UnitOfMeasurement"
     },
     "identifier": {
       "@id": "schema:identifier"
@@ -117,6 +204,102 @@
     },
     "spatial": {
       "@id": "schema:spatial",
+      "@type": "@id"
+    },
+    "manufacturer": {
+      "@id": "schema:manufacturer",
+      "@type": "@id"
+    },
+    "brand": {
+      "@id": "schema:brand",
+      "@type": "xsd:string"
+    },
+    "model": {
+      "@id": "schema:model",
+      "@type": "xsd:string"
+    },
+    "productID": {
+      "@id": "schema:productID",
+      "@type": "xsd:string"
+    },
+    "productionDate": {
+      "@id": "schema:productionDate",
+      "@type": "xsd:date"
+    },
+    "purchaseDate": {
+      "@id": "schema:purchaseDate",
+      "@type": "xsd:date"
+    },
+    "serialNumber": {
+      "@id": "schema:serialNumber",
+      "@type": "xsd:string"
+    },
+    "username": {
+      "@id": "mat:username",
+      "@type": "xsd:string"
+    },
+    "password": {
+      "@id": "mat:password",
+      "@type": "xsd:string"
+    },
+    "requirePasswordChange": {
+      "@id": "mat:requirePasswordChange"
+    },
+    "publicKey": {
+      "@id": "mat:publicKey"
+    },
+    "measurementTechnique": {
+      "@id": "schema:measurementTechnique",
+      "@type": "@id"
+    },
+    "variableMeasured": {
+      "@id": "schema:variableMeasured"
+    },
+    "parameterControlled": {
+      "@id": "mat:parameterControlled"
+    },
+    "conditionObserved": {
+      "@id": "mat:conditionObserved"
+    },
+    "material": {
+      "@id": "schema:material",
+      "@type": "@id"
+    },
+    "materialExtent": {
+      "@id": "schema:materialExtent"
+    },
+    "materialReference": {
+      "@id": "mat:materialReference",
+      "@type": "@id"
+    },
+    "materialReferenceExtent": {
+      "@id": "mat:materialReferenceExtent"
+    },
+    "includedInDataCatalog": {
+      "@id": "schema:includedInDataCatalog",
+      "@type": "@id"
+    },
+    "uploadDate": {
+      "@id": "schema:uploadDate",
+      "@type": "xsd:date"
+    },
+    "distribution": {
+      "@id": "schema:distribution"
+    },
+    "hasPart": {
+      "@id": "schema:hasPart",
+      "@type": "@id"
+    },
+    "isPartOf": {
+      "@id": "schema:isPartOf",
+      "@type": "@id"
+    },
+    "isBasedOn": {
+      "@id": "schema:isBasedOn",
+      "@type": "@id"
+    },
+    "exampleOfWork": {
+      "@id": "schema:exampleOfWork",
       "@type": "@id"
     }
   }


### PR DESCRIPTION
This PR doesn't update any schemas, but adds two script for converting Cordra-style json schemas to RDF syntaxes. The first (`CordraToRDFSchema.py`), converts the schemas to RDF Schema. The second (`CordraToContext.py`), converts the schemas to a json-ld context.

However, it is not possible to convert from Cordra-style json-schemas to RDF without significant user knowledge. The user's knowledge affected several key variables in the conversion scripts, including:
* **Custom subtype interpretation**. `AllOf` includes all superclasses of a schema, but since CreativeWork is not its own schema, it cannot specify that it is a subtype of Thing. A custom function was used to eliminate Thing from `subtypeOf` relations that also included CreativeWork.
* **Custom Types**. RDF has many more types than string, number, object, boolean, and array. Custom type interpretation was included in the scripts for dates, urls, and CordraReferences.
* **Lack of IRIs**. RDF has the concept of IRIs, which are not in json-schema. This script checks if a schema is in http://schema.org/ and gives it the `schema:` prefix for compact IRI notation. If an object is not in schema.org, it is given the `mat:` prefix.